### PR TITLE
Oni Update 3

### DIFF
--- a/ItemProperties.h
+++ b/ItemProperties.h
@@ -1,0 +1,25 @@
+// ItemProperties.h
+
+#pragma once
+
+#include <unordered_map>
+#include <string>
+#include <iostream>
+
+struct ItemProperties {
+    double melee_cast_time;
+    double melee_recover_time;
+    double melee_stun;
+    int melee_range;
+    int melee_cost;
+
+    ItemProperties() : melee_cast_time(0), melee_recover_time(0), melee_stun(0), melee_range(0), melee_cost(0) {}
+    ItemProperties(double cast, double recover, double stun, int range, int cost)
+        : melee_cast_time(cast), melee_recover_time(recover), melee_stun(stun), melee_range(range), melee_cost(cost) {}
+};
+
+// Declare itemData with extern to signal it's defined elsewhere
+extern std::unordered_map<std::string, ItemProperties> itemData;
+
+void InitializeItems();
+ItemProperties GetItemProperties(const std::string& itemName);

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Game Enhancement Tool (Fork of Lockdown Protocol External)
+
+This project is a fork of the [Lockdown Protocol External](https://github.com/psZachary/lockdown-protocol-external) by [psZachary](https://github.com/psZachary). This fork extends the original functionality by adding enhanced item data management, overlay improvements, and various player enhancement features.
+
+## Features
+- **Player Enhancements**: Toggle options for god mode, infinite ammo, infinite stamina, and more.
+- **Overlay and ESP**: Visual overlay that displays information about players and items in the game.
+- **Fast Melee and Infinite Melee Range**: Modify melee properties for faster actions or extended range.
+
+## File Structure
+- `main.cpp`: Core logic and main game loop with memory and overlay management.
+- `ItemProperties.h`: Defines item properties structure and initializes game item data for quick lookups.
+- `overlay/`: Contains code for rendering the in-game overlay.
+- `util.hpp`: Utility functions for string manipulation, memory, and more.
+
+## Setup and Usage
+1. **Clone the Repository**:
+   ```bash
+   git clone https://github.com/OniSensei/lockdown-protocol-external.git
+   cd lockdown-protocol-external
+   ```
+
+2. **Project Configuration**:
+   - Ensure paths to "Header Files" are correctly set if using Visual Studio.
+   - Add the project’s include directories to the IDE’s include path.
+
+3. **Build and Run**:
+   - Compile and build the project in your IDE.
+   - Run the executable with the target game open.
+   - You must have [medal.tv](https://medal.tv/) installed and running.
+
+## Example Usage
+- Toggle features like infinite ammo or god mode using function keys (e.g., `F2` for player ESP, `F8` for infinite stamina).
+
+## Code Example
+```cpp
+// Accessing item properties
+ItemProperties knifeProps = GetItemProperties("KNIFE");
+std::cout << "KNIFE cast time: " << knifeProps.melee_cast_time << std::endl;
+```
+
+## Original Project
+This project is a fork of [psZachary's Lockdown Protocol External](https://github.com/psZachary/lockdown-protocol-external), with additional enhancements focused on item properties and gameplay customization.
+
+## Contributing
+Feel free to submit issues, fork the repository, and make pull requests to enhance features, fix bugs, or improve performance.

--- a/config.h
+++ b/config.h
@@ -3,19 +3,21 @@
 namespace config {
 	inline bool player_esp = true;
 	inline bool weapon_esp = true;
+	inline bool weapon_details = true;
 	inline bool primary_object_esp = true;
+	inline bool primary_object_details = true;
 	inline bool secondary_object_esp = true;
+	inline bool secondary_object_details = true;
 	inline bool speedhack = false;
 	inline bool fast_melee = false;
-	inline bool set_fast_melee = false;
 	inline bool max_damage = false;
 	inline bool infinite_stamina = false;
 	inline bool god_mode = false;
+	inline bool can_inventory = false;
 	inline bool auto_fire = false;
 	inline bool rapid_fire = false;
 	inline bool no_recoil = true;
 	inline bool infinite_melee_range = false;
-	inline bool set_melee_range = false;
 	inline bool living_state = false;
 	inline bool infinite_ammo = false;
 }

--- a/game_structures.hpp
+++ b/game_structures.hpp
@@ -414,7 +414,6 @@ namespace protocol {
 	namespace game {
 		using namespace engine::sdk;
 		namespace sdk {
-			
 			class u_data_item : public u_object {
 			public:
 				GET_OFFSET(0x30, name, fstring);
@@ -482,6 +481,7 @@ namespace protocol {
 			public:
 				GET_OFFSET(0x3B8, data, u_data_item*);
 				GET_OFFSET(0x448, distance, float);
+				OFFSET(0x3C8, item_state, FStr_ItemState);
 			};
 			class u_data_player : public u_object {
 			public:
@@ -509,6 +509,7 @@ namespace protocol {
 				OFFSET(0xC99, alive, bool);
 				OFFSET(0x4D4, onfloor, bool);
 				OFFSET(0xD72, can_play, bool);
+				OFFSET(0x1058, in_game, bool);
 				OFFSET(0x568, run, bool);
 				OFFSET(0x569, walk, bool);
 				OFFSET(0x0710, acceleration, vector2);
@@ -528,6 +529,8 @@ namespace protocol {
 				OFFSET(0x0B80, mec_speed, double);
 				OFFSET(0x0610, recovery, double);
 				OFFSET(0x0DD0, friction, double);
+				OFFSET(0x970, body_armor_color, double);
+				OFFSET(0x1134, skin_color, int32_t);
 				OFFSET(0x870, hand_state, FStr_ItemState);
 				OFFSET(0x880, bag_state, FStr_ItemState);
 				OFFSET(0x0A40, player_data, u_data_player*);

--- a/main.cpp
+++ b/main.cpp
@@ -201,26 +201,28 @@ static void render_callback() {
         }
     }
 
-    if (!fast_melee) {
-        auto mtype = melee_item_data->get_melee_type();
-        std::string item_name = hand_item->get_name().read_string();
-        ItemProperties itemprops = GetItemProperties(item_name);
-
+    if (hand_item) {
         if (!fast_melee) {
-            mtype->set_cast_time(itemprops.melee_cast_time);
-            mtype->set_recover_time(itemprops.melee_recover_time);
-            mtype->set_stun(itemprops.melee_stun);
-            mtype->set_cost(itemprops.melee_cost);
-        }
-    }
+            auto mtype = melee_item_data->get_melee_type();
+            std::string item_name = hand_item->get_name().read_string();
+            ItemProperties itemprops = GetItemProperties(item_name);
 
-    if (!infinite_melee_range) {
-        auto mtype = melee_item_data->get_melee_type();
-        std::string item_name = hand_item->get_name().read_string();
-        ItemProperties itemprops = GetItemProperties(item_name);
+            if (!fast_melee) {
+                mtype->set_cast_time(itemprops.melee_cast_time);
+                mtype->set_recover_time(itemprops.melee_recover_time);
+                mtype->set_stun(itemprops.melee_stun);
+                mtype->set_cost(itemprops.melee_cost);
+            }
+        }
 
         if (!infinite_melee_range) {
-            mtype->set_range(itemprops.melee_range);
+            auto mtype = melee_item_data->get_melee_type();
+            std::string item_name = hand_item->get_name().read_string();
+            ItemProperties itemprops = GetItemProperties(item_name);
+
+            if (!infinite_melee_range) {
+                mtype->set_range(itemprops.melee_range);
+            }
         }
     }
 

--- a/menu.cpp
+++ b/menu.cpp
@@ -7,6 +7,8 @@
 using namespace globals;
 using namespace config;
 
+int selected_tab = 1;
+
 void menu::draw()
 {
 	static bool menu_open = true;
@@ -15,250 +17,501 @@ void menu::draw()
 	}
 
 	if (menu_open) {
+		ImVec2 startPosition = ImVec2(20, 20);
 
-		ImGui::Begin("Hawk Tuah Protocol", 0, ImGuiWindowFlags_AlwaysAutoResize);
+		ImGui::SetNextWindowPos(startPosition, true ? ImGuiCond_Once : ImGuiCond_Always);
 
-		// imvec4 - rbga - 1.0 = 100% (or 255) 
+		ImGui::Begin("Hawk Tuah Protocol - Oni Edition"); 
+
 		ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.1059f, 0.3765f, 0.6510f, 1.0f));
+		ImGui::PushStyleColor(ImGuiCol_SliderGrab, ImVec4(0.1059f, 0.3765f, 0.6510f, 1.0f));
+		ImGui::PushStyleColor(ImGuiCol_SliderGrabActive, ImVec4(0.1059f, 0.3765f, 0.6510f, 1.0f));
 
-		if (ImGui::CollapsingHeader("ESP", ImGuiTreeNodeFlags_DefaultOpen)) {
-			ImGui::Checkbox("[F2] Player ESP", &player_esp);
-			ImGui::Checkbox("[F3] Weapon ESP", &weapon_esp);
-			ImGui::Checkbox("[F4] Object ESP", &primary_object_esp);
-			ImGui::Checkbox("[F5] Other Object ESP", &secondary_object_esp);
-		}
-		if (ImGui::CollapsingHeader("PLAYER", ImGuiTreeNodeFlags_DefaultOpen)) {
-			ImGui::Checkbox("[F6] Speedhack", &speedhack);
-			ImGui::Checkbox("[F7] God Mode", &god_mode);
-			ImGui::Checkbox("[F8] Infinite Stamina", &infinite_stamina);
-			ImGui::Checkbox("[F9] Revive", &living_state);
-		}
+		float calculatedHeight = 0.0f;
+		float itemHeight = ImGui::GetFrameHeightWithSpacing();
+		float headerPadding = 15.0f;
 
-		if (ImGui::CollapsingHeader("WEAPON", ImGuiTreeNodeFlags_DefaultOpen)) {
-			ImGui::Checkbox("Fast Melee", &fast_melee);
-			ImGui::Checkbox("Infinite Melee Range", &infinite_melee_range);
-			ImGui::Separator();
-			ImGui::Checkbox("Auto Fire", &auto_fire);
-			ImGui::Checkbox("Rapid Fire", &rapid_fire);
-			ImGui::Checkbox("No Recoil", &no_recoil);
-			ImGui::Checkbox("Max Damage", &max_damage);
-			ImGui::Checkbox("Infinite Ammo", &infinite_ammo);
+		ImGui::BeginChild("Sidebar", ImVec2(75, 0), true);
+		if (ImGui::Selectable("ESP", selected_tab == 1)) selected_tab = 1;
+		if (ImGui::Selectable("PLAYER", selected_tab == 2)) selected_tab = 2;
+		if (ImGui::Selectable("WEAPON", selected_tab == 3)) selected_tab = 3;
+		if (ImGui::Selectable("ITEMS", selected_tab == 4)) selected_tab = 4;
+		ImGui::EndChild();
+
+		ImGui::SameLine();
+		ImGui::BeginChild("Content");
+
+		if (selected_tab == 1) { // ESP
+			calculatedHeight += itemHeight + headerPadding;
+			ImGui::Checkbox("[F2] Player ESP", &player_esp); calculatedHeight += itemHeight;
+			ImGui::Checkbox("[F3] Weapon ESP", &weapon_esp); calculatedHeight += itemHeight;
+			if (weapon_esp) {
+				ImGui::Indent();
+				ImGui::Checkbox("Show Details##weapon", &weapon_details);
+				calculatedHeight += itemHeight;
+				ImGui::Unindent();
+			}
+			ImGui::Checkbox("[F4] Object ESP", &primary_object_esp); calculatedHeight += itemHeight;
+			if (primary_object_esp) {
+				ImGui::Indent();
+				ImGui::Checkbox("Show Details##primary", &primary_object_details);
+				calculatedHeight += itemHeight;
+				ImGui::Unindent();
+			}
+			ImGui::Checkbox("[F5] Other Object ESP", &secondary_object_esp); calculatedHeight += itemHeight;
+			if (secondary_object_esp) {
+				ImGui::Indent();
+				ImGui::Checkbox("Show Details##secondary", &secondary_object_details);
+				calculatedHeight += itemHeight;
+				ImGui::Unindent();
+			}
 		}
-		if (ImGui::CollapsingHeader("ITEMS", ImGuiTreeNodeFlags_DefaultOpen)) {
+		else if (selected_tab == 2) { // PLAYER
+			calculatedHeight += itemHeight + headerPadding;
+			ImGui::Checkbox("[F6] Speedhack", &speedhack); calculatedHeight += itemHeight;
+			ImGui::Checkbox("[F7] God Mode", &god_mode); calculatedHeight += itemHeight;
+			ImGui::Checkbox("[F8] Infinite Stamina", &infinite_stamina); calculatedHeight += itemHeight;
+			ImGui::Checkbox("[F9] Revive", &living_state); calculatedHeight += itemHeight;
+		}
+		else if (selected_tab == 3) { // WEAPON
+			if (ImGui::CollapsingHeader("MELEE", ImGuiTreeNodeFlags_DefaultOpen)) {
+				calculatedHeight += itemHeight + headerPadding;
+				ImGui::Checkbox("Fast Melee", &fast_melee); calculatedHeight += itemHeight;
+				ImGui::Checkbox("Infinite Melee Range", &infinite_melee_range); calculatedHeight += itemHeight;
+			}
+			calculatedHeight += itemHeight;
+			if (ImGui::CollapsingHeader("GUN", ImGuiTreeNodeFlags_DefaultOpen)) {
+				ImGui::Checkbox("Auto Fire", &auto_fire); calculatedHeight += itemHeight;
+				ImGui::Checkbox("Rapid Fire", &rapid_fire); calculatedHeight += itemHeight;
+				ImGui::Checkbox("No Recoil", &no_recoil); calculatedHeight += itemHeight;
+				ImGui::Checkbox("Max Damage", &max_damage); calculatedHeight += itemHeight;
+				ImGui::Checkbox("Infinite Ammo", &infinite_ammo); calculatedHeight += itemHeight;
+			}
+			calculatedHeight += itemHeight;
+		}
+		else if (selected_tab == 4) { // ITEMS
 			auto hand_item = local_mec->get_hand_item();
 			auto bag_item = local_mec->get_bag_item();
 			auto hand_inventory = hand_item->get_can_inventory();
 
+			if (ImGui::CollapsingHeader("INVENTORY", ImGuiTreeNodeFlags_DefaultOpen)) {
+				if (hand_item) {
+
+					std::string hand_item_name = hand_item->get_name().read_string();
+
+					std::string display_name;
+					if (hand_item_name == "NAME") {
+						display_name = "PIZZUSHI";
+					}
+					else {
+						display_name = hand_item_name;
+					}
+					ImGui::Text("Hand Item: %s", display_name.c_str());
+					calculatedHeight += itemHeight;
+
+					auto hand_state = local_mec->get_hand_state();
+					if (hand_item->get_name().read_string() == "GAZ BOTTLE") {
+						const char* colors[] = { "Yellow", "Red", "Blue" };
+						int current_value = hand_state.Value_8;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##Color", &current_value, colors, IM_ARRAYSIZE(colors))) {
+							hand_state.Value_8 = current_value;
+							local_mec->set_hand_state(hand_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (hand_item->get_name().read_string() == "PACKAGE") {
+						const char* package_types[] = { "Security", "Computers", "Botanic", "Restaurant", "Medical", "Tutorial" , "Machine" };
+						int package_value = hand_state.Value_8 - 1;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##PackageTypes", &package_value, package_types, IM_ARRAYSIZE(package_types))) {
+							hand_state.Value_8 = package_value + 1;
+							local_mec->set_hand_state(hand_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (hand_item->get_name().read_string() == "FISH") {
+						const char* fish_types[] = { "Salmon", "Tuna", "Cod", "Shrimp" };
+						int fish_value = hand_state.Value_8 - 1;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##FishType", &fish_value, fish_types, IM_ARRAYSIZE(fish_types))) {
+							hand_state.Value_8 = fish_value + 1;
+							local_mec->set_hand_state(hand_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (hand_item->get_name().read_string() == "RICE") {
+						const char* rice_types[] = { "White", "Brown", "Black" };
+						int rice_value = hand_state.Value_8 - 1;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##RiceType", &rice_value, rice_types, IM_ARRAYSIZE(rice_types))) {
+							hand_state.Value_8 = rice_value + 1;
+							local_mec->set_hand_state(hand_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (hand_item->get_name().read_string() == "PACKAGE") {
+						const char* package_types[] = { "Security", "Computers", "Botanic", "Restaurant", "Medical", "Tutorial" , "Machine" };
+						int package_value = hand_state.Value_8 - 1;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##PackageTypes", &package_value, package_types, IM_ARRAYSIZE(package_types))) {
+							hand_state.Value_8 = package_value + 1;
+							local_mec->set_hand_state(hand_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (hand_item->get_name().read_string() == "FISH") {
+						const char* fish_types[] = { "Salmon", "Tuna", "Cod", "Shrimp" };
+						int fish_value = hand_state.Value_8 - 1;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##FishType", &fish_value, fish_types, IM_ARRAYSIZE(fish_types))) {
+							hand_state.Value_8 = fish_value + 1;
+							local_mec->set_hand_state(hand_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (hand_item->get_name().read_string() == "RICE") {
+						const char* rice_types[] = { "White", "Brown", "Black" };
+						int rice_value = hand_state.Value_8 - 1;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##RiceType", &rice_value, rice_types, IM_ARRAYSIZE(rice_types))) {
+							hand_state.Value_8 = rice_value + 1;
+							local_mec->set_hand_state(hand_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (hand_item->get_name().read_string() == "CONTAINER") {
+						const char* colors[] = { "Empty", "Green", "Yellow", "Blue", "White", "Red", "White Rice", "Brown Rice", "Black Rice" };
+						int current_value = hand_state.Value_8;
+						int selected_index = current_value;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##Color", &selected_index, colors, IM_ARRAYSIZE(colors))) {
+							if (selected_index >= 6) {
+								hand_state.Value_8 = 6;
+								switch (selected_index) {
+								case 6: hand_state.Time_15 = 1; break;
+								case 7: hand_state.Time_15 = 2; break;
+								case 8: hand_state.Time_15 = 3; break;
+								}
+							}
+							else {
+								hand_state.Value_8 = selected_index;
+								hand_state.Time_15 = 0;
+							}
+							local_mec->set_hand_state(hand_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (hand_item->get_name().read_string() == "SAMPLE") {
+						const char* colors[] = { "Green", "Yellow", "Blue", "White", "Red" };
+						int current_index = hand_state.Value_8 - 1;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##SampleColor", &current_index, colors, IM_ARRAYSIZE(colors))) {
+							hand_state.Value_8 = current_index + 1;
+							local_mec->set_hand_state(hand_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (hand_item->get_name().read_string() == "FUSE") {
+						const char* fuse_colors[] = { "Red", "Yellow", "Blue" };
+						int time_color = hand_state.Time_15 - 1;
+						int value_color = hand_state.Value_8 - 1;
+
+						float half_width = (ImGui::GetContentRegionAvail().x - 10) / 2;
+
+						ImGui::SetNextItemWidth(half_width);
+						if (ImGui::Combo("##ValueColor", &value_color, fuse_colors, IM_ARRAYSIZE(fuse_colors))) {
+							hand_state.Value_8 = value_color + 1;
+							local_mec->set_hand_state(hand_state);
+						}
+						calculatedHeight += itemHeight;
+
+						ImGui::SameLine();
+						ImGui::SetNextItemWidth(half_width);
+						if (ImGui::Combo("##TimeColor", &time_color, fuse_colors, IM_ARRAYSIZE(fuse_colors))) {
+							hand_state.Time_15 = time_color + 1;
+							local_mec->set_hand_state(hand_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (hand_item->get_name().read_string() == "NAME") {
+						const char* rice_options[] = { "White Rice", "Brown Rice", "Black Rice" };
+						const char* fish_options[] = { "Salmon", "Tuna", "Cod", "Shrimp" };
+						const char* container_colors[] = { "Green", "Yellow", "Blue", "White", "Red" };
+
+						int value = hand_state.Value_8;
+						int rice_value = value / 100;
+						int fish_value = (value / 10) % 10;
+						int container_value = value % 10;
+
+						int rice_index = rice_value - 1;
+						int fish_index = fish_value - 1;
+						int container_index = container_value - 1;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##Rice", &rice_index, rice_options, IM_ARRAYSIZE(rice_options))) {
+							rice_value = rice_index + 1;
+						}
+						calculatedHeight += itemHeight;
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##Fish", &fish_index, fish_options, IM_ARRAYSIZE(fish_options))) {
+							fish_value = fish_index + 1;
+						}
+						calculatedHeight += itemHeight;
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##Container Color", &container_index, container_colors, IM_ARRAYSIZE(container_colors))) {
+							container_value = container_index + 1;
+						}
+						calculatedHeight += itemHeight;
+
+						hand_state.Value_8 = (rice_value * 100) + (fish_value * 10) + container_value;
+						local_mec->set_hand_state(hand_state);
+					} // Pizzushi
+					else if (hand_item->get_name().read_string() == "VENT FILTER") {
+						int clean_percentage = hand_state.Value_8;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 20);
+						if (ImGui::SliderInt("%", &clean_percentage, 0, 100)) {
+							hand_state.Value_8 = clean_percentage;
+							local_mec->set_hand_state(hand_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (hand_item->get_name().read_string() == "BATTERY") {
+						int charge_percentage = hand_state.Value_8;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 20);
+						if (ImGui::SliderInt("%", &charge_percentage, 0, 100)) {
+							hand_state.Value_8 = charge_percentage;
+							local_mec->set_hand_state(hand_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+				}
+				else {
+					ImGui::Text("Hand Item: AIR");
+					calculatedHeight += itemHeight + 10;
+				}
+				if (bag_item) {
+					std::string bag_item_name = bag_item->get_name().read_string();
+
+					std::string display_name;
+					if (bag_item_name == "NAME") {
+						display_name = "PIZZUSHI";
+					}
+					else {
+						display_name = bag_item_name;
+					}
+					ImGui::Text("Bag Item: %s", display_name.c_str());
+					calculatedHeight += itemHeight;
+
+					auto bag_state = local_mec->get_bag_state();
+					if (bag_item->get_name().read_string() == "GAZ BOTTLE") {
+						const char* colors[] = { "Yellow", "Red", "Blue" };
+						int current_value = bag_state.Value_8;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##Color", &current_value, colors, IM_ARRAYSIZE(colors))) {
+							bag_state.Value_8 = current_value;
+							local_mec->set_bag_state(bag_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (bag_item->get_name().read_string() == "PACKAGE") {
+						const char* package_types[] = { "Security", "Computers", "Botanic", "Restaurant", "Medical", "Tutorial" , "Machine" };
+						int package_value = bag_state.Value_8 - 1;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##PackageTypes", &package_value, package_types, IM_ARRAYSIZE(package_types))) {
+							bag_state.Value_8 = package_value + 1;
+							local_mec->set_bag_state(bag_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (bag_item->get_name().read_string() == "FISH") {
+						const char* fish_types[] = { "Salmon", "Tuna", "Cod", "Shrimp" };
+						int fish_value = bag_state.Value_8 - 1;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##FishType", &fish_value, fish_types, IM_ARRAYSIZE(fish_types))) {
+							bag_state.Value_8 = fish_value + 1;
+							local_mec->set_bag_state(bag_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (bag_item->get_name().read_string() == "RICE") {
+						const char* rice_types[] = { "White", "Brown", "Black" };
+						int rice_value = bag_state.Value_8 - 1;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##RiceType", &rice_value, rice_types, IM_ARRAYSIZE(rice_types))) {
+							bag_state.Value_8 = rice_value + 1;
+							local_mec->set_bag_state(bag_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (bag_item->get_name().read_string() == "CONTAINER") {
+						const char* colors[] = { "Empty", "Green", "Yellow", "Blue", "White", "Red", "White Rice", "Brown Rice", "Black Rice" };
+						int current_value = bag_state.Value_8;
+						int selected_index = current_value;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##Color", &selected_index, colors, IM_ARRAYSIZE(colors))) {
+							if (selected_index >= 6) {
+								bag_state.Value_8 = 6;
+								switch (selected_index) {
+								case 6: bag_state.Time_15 = 1; break;
+								case 7: bag_state.Time_15 = 2; break;
+								case 8: bag_state.Time_15 = 3; break;
+								}
+							}
+							else {
+								bag_state.Value_8 = selected_index;
+								bag_state.Time_15 = 0;
+							}
+							local_mec->set_bag_state(bag_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (bag_item->get_name().read_string() == "SAMPLE") {
+						const char* colors[] = { "Green", "Yellow", "Blue", "White", "Red" };
+						int current_index = bag_state.Value_8 - 1;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##SampleColor", &current_index, colors, IM_ARRAYSIZE(colors))) {
+							bag_state.Value_8 = current_index + 1;
+							local_mec->set_bag_state(bag_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (bag_item->get_name().read_string() == "FUSE") {
+						const char* fuse_colors[] = { "Red", "Yellow", "Blue" };
+						int time_color = bag_state.Time_15 - 1;
+						int value_color = bag_state.Value_8 - 1;
+
+						float half_width = (ImGui::GetContentRegionAvail().x - 10) / 2;
+
+						ImGui::SetNextItemWidth(half_width);
+						if (ImGui::Combo("##ValueColor", &value_color, fuse_colors, IM_ARRAYSIZE(fuse_colors))) {
+							bag_state.Value_8 = value_color + 1;
+							local_mec->set_bag_state(bag_state);
+						}
+						calculatedHeight += itemHeight;
+
+						ImGui::SameLine();
+						ImGui::SetNextItemWidth(half_width);
+						if (ImGui::Combo("##TimeColor", &time_color, fuse_colors, IM_ARRAYSIZE(fuse_colors))) {
+							bag_state.Time_15 = time_color + 1;
+							local_mec->set_bag_state(bag_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+					else if (bag_item->get_name().read_string() == "NAME") { // Pizzushi
+						const char* rice_options[] = { "White Rice", "Brown Rice", "Black Rice" };
+						const char* fish_options[] = { "Salmon", "Tuna", "Cod", "Shrimp" };
+						const char* container_colors[] = { "Green", "Yellow", "Blue", "White", "Red" };
+
+						int value = bag_state.Value_8;
+						int rice_value = value / 100;
+						int fish_value = (value / 10) % 10;
+						int container_value = value % 10;
+
+						int rice_index = rice_value - 1;
+						int fish_index = fish_value - 1;
+						int container_index = container_value - 1;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##Rice", &rice_index, rice_options, IM_ARRAYSIZE(rice_options))) {
+							rice_value = rice_index + 1;
+						}
+						calculatedHeight += itemHeight;
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##Fish", &fish_index, fish_options, IM_ARRAYSIZE(fish_options))) {
+							fish_value = fish_index + 1;
+						}
+						calculatedHeight += itemHeight;
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+						if (ImGui::Combo("##Container Color", &container_index, container_colors, IM_ARRAYSIZE(container_colors))) {
+							container_value = container_index + 1;
+						}
+						calculatedHeight += itemHeight;
+
+						bag_state.Value_8 = (rice_value * 100) + (fish_value * 10) + container_value;
+						local_mec->set_bag_state(bag_state);
+					}
+					else if (bag_item->get_name().read_string() == "VENT FILTER") {
+						int clean_percentage = bag_state.Value_8;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 20);
+						if (ImGui::SliderInt("%", &clean_percentage, 0, 100)) {
+							bag_state.Value_8 = clean_percentage;
+							local_mec->set_bag_state(bag_state);
+						}
+						if (!ImGui::IsItemDeactivatedAfterEdit())
+							calculatedHeight += itemHeight;
+					}
+					else if (bag_item->get_name().read_string() == "BATTERY") {
+						int charge_percentage = bag_state.Value_8;
+
+						ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 20);
+						if (ImGui::SliderInt("%", &charge_percentage, 0, 100)) {
+							bag_state.Value_8 = charge_percentage;
+							local_mec->set_bag_state(bag_state);
+						}
+						calculatedHeight += itemHeight;
+					}
+				}
+				else {
+					ImGui::Text("Bag Item: EMPTY");
+					calculatedHeight += itemHeight + 10;
+				}
+				calculatedHeight += itemHeight;
+			}
+			calculatedHeight += itemHeight;
+
 			if (hand_item) {
-				ImGui::Text("Hand Item: %s", hand_item->get_name().read_string().c_str());
-				auto hand_state = local_mec->get_hand_state();
-				//std::cout << "Hand item changed: " << hand_item->get_name().read_string().c_str() << " - " << hand_state.Value_8 << " | " << hand_state.Time_15 << std::endl;
-
-				if (hand_item->get_name().read_string() == "GAZ BOTTLE") {
-					const char* colors[] = { "Yellow", "Red", "Blue" };
-					int current_value = hand_state.Value_8;
-
-					ImGui::SetNextItemWidth(75.0f);
-					if (ImGui::Combo("##Color", &current_value, colors, IM_ARRAYSIZE(colors))) {
-						hand_state.Value_8 = current_value;
-						local_mec->set_hand_state(hand_state);
+				if (!hand_inventory) {
+					ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+					if (ImGui::Button("Can Inventory", ImVec2(ImGui::GetContentRegionAvail().x - 10, 0))) {
+						if (hand_item) {
+							hand_item->set_can_inventory(!hand_inventory);
+						}
 					}
+					calculatedHeight += itemHeight;
 				}
-				else if (hand_item->get_name().read_string() == "PACKAGE") {
-					const char* package_types[] = { "Security", "Computers", "Botanic", "Restaurant", "Medical", "Tutorial" , "Machine" };
-					int package_value = hand_state.Value_8 - 1;
-
-					ImGui::SetNextItemWidth(95.0f);
-					if (ImGui::Combo("##PackageTypes", &package_value, package_types, IM_ARRAYSIZE(package_types))) {
-						hand_state.Value_8 = package_value + 1;
-						local_mec->set_hand_state(hand_state);
+				else {
+					ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 10);
+					if (ImGui::Button("Can't Inventory", ImVec2(ImGui::GetContentRegionAvail().x - 10, 0))) {
+						if (hand_item) {
+							hand_item->set_can_inventory(!hand_inventory);
+						}
 					}
-				}
-				else if (hand_item->get_name().read_string() == "RICE") {
-					const char* rice_types[] = { "White", "Brown", "Black" };
-					int rice_value = hand_state.Value_8 - 1;
-
-					ImGui::SetNextItemWidth(75.0f);
-					if (ImGui::Combo("##RiceType", &rice_value, rice_types, IM_ARRAYSIZE(rice_types))) {
-						hand_state.Value_8 = rice_value + 1;
-						local_mec->set_hand_state(hand_state);
-					}
-				}
-				else if (hand_item->get_name().read_string() == "CONTAINER") {
-					const char* colors[] = { "Empty", "Green", "Yellow", "Blue", "White", "Red" };
-					int current_value = hand_state.Value_8;
-
-					ImGui::SetNextItemWidth(75.0f);
-					if (ImGui::Combo("##Color", &current_value, colors, IM_ARRAYSIZE(colors))) {
-						hand_state.Value_8 = current_value;
-						local_mec->set_hand_state(hand_state);
-					}
-				}
-				else if (hand_item->get_name().read_string() == "SAMPLE") {
-					const char* colors[] = { "Green", "Yellow", "Blue", "White", "Red" };
-					int current_index = hand_state.Value_8 - 1;
-
-					ImGui::SetNextItemWidth(75.0f);
-					if (ImGui::Combo("##SampleColor", &current_index, colors, IM_ARRAYSIZE(colors))) {
-						hand_state.Value_8 = current_index + 1;
-						local_mec->set_hand_state(hand_state);
-					}
-				}
-				else if (hand_item->get_name().read_string() == "FUSE") {
-					const char* fuse_colors[] = { "Red", "Yellow", "Blue" };
-					int time_color = hand_state.Time_15 - 1;
-					int value_color = hand_state.Value_8 - 1;
-
-					ImGui::SetNextItemWidth(75.0f);
-					if (ImGui::Combo("##ValueColor", &value_color, fuse_colors, IM_ARRAYSIZE(fuse_colors))) {
-						hand_state.Value_8 = value_color + 1;
-						local_mec->set_hand_state(hand_state);
-					}
-
-					ImGui::SameLine();
-					ImGui::SetNextItemWidth(75.0f);
-					if (ImGui::Combo("##TimeColor", &time_color, fuse_colors, IM_ARRAYSIZE(fuse_colors))) {
-						hand_state.Time_15 = time_color + 1;
-						local_mec->set_hand_state(hand_state);
-					}
-				}
-				else if (hand_item->get_name().read_string() == "VENT FILTER") {
-					int clean_percentage = hand_state.Value_8;
-
-					ImGui::SetNextItemWidth(90.0f);
-					if (ImGui::SliderInt("Clean %", &clean_percentage, 0, 100)) {
-						hand_state.Value_8 = clean_percentage;
-						local_mec->set_hand_state(hand_state);
-					}
-				}
-				else if (hand_item->get_name().read_string() == "BATTERY") {
-					int charge_percentage = hand_state.Value_8;
-
-					ImGui::SetNextItemWidth(90.0f);
-					if (ImGui::SliderInt("Charge %", &charge_percentage, 0, 100)) {
-						hand_state.Value_8 = charge_percentage;
-						local_mec->set_hand_state(hand_state);
-					}
-				}
-			}
-			else {
-				ImGui::Text("Hand Item: AIR");
-			}
-			if (bag_item) {
-				ImGui::Text("bag Item: %s", bag_item->get_name().read_string().c_str());
-				auto bag_state = local_mec->get_bag_state();
-				//std::cout << "bag item changed: " << bag_item->get_name().read_string().c_str() << " - " << bag_state.Value_8 << " | " << bag_state.Time_15 << std::endl;
-
-				if (bag_item->get_name().read_string() == "GAZ BOTTLE") {
-					const char* colors[] = { "Yellow", "Red", "Blue" };
-					int current_value = bag_state.Value_8;
-
-					ImGui::SetNextItemWidth(75.0f);
-					if (ImGui::Combo("##Color", &current_value, colors, IM_ARRAYSIZE(colors))) {
-						bag_state.Value_8 = current_value;
-						local_mec->set_bag_state(bag_state);
-					}
-				}
-				else if (bag_item->get_name().read_string() == "PACKAGE") {
-					const char* package_types[] = { "Security", "Computers", "Botanic", "Restaurant", "Medical", "Tutorial" , "Machine" };
-					int package_value = bag_state.Value_8 - 1;
-
-					ImGui::SetNextItemWidth(95.0f);
-					if (ImGui::Combo("##PackageTypes", &package_value, package_types, IM_ARRAYSIZE(package_types))) {
-						bag_state.Value_8 = package_value + 1;
-						local_mec->set_bag_state(bag_state);
-					}
-				}
-				else if (bag_item->get_name().read_string() == "RICE") {
-					const char* rice_types[] = { "White", "Brown", "Black" };
-					int rice_value = bag_state.Value_8 - 1;
-
-					ImGui::SetNextItemWidth(75.0f);
-					if (ImGui::Combo("##RiceType", &rice_value, rice_types, IM_ARRAYSIZE(rice_types))) {
-						bag_state.Value_8 = rice_value + 1;
-						local_mec->set_bag_state(bag_state);
-					}
-				}
-				else if (bag_item->get_name().read_string() == "CONTAINER") {
-					const char* colors[] = { "Empty", "Green", "Yellow", "Blue", "White", "Red" };
-					int current_value = bag_state.Value_8;
-
-					ImGui::SetNextItemWidth(75.0f);
-					if (ImGui::Combo("##Color", &current_value, colors, IM_ARRAYSIZE(colors))) {
-						bag_state.Value_8 = current_value;
-						local_mec->set_bag_state(bag_state);
-					}
-				}
-				else if (bag_item->get_name().read_string() == "SAMPLE") {
-					const char* colors[] = { "Green", "Yellow", "Blue", "White", "Red" };
-					int current_index = bag_state.Value_8 - 1;
-
-					ImGui::SetNextItemWidth(75.0f);
-					if (ImGui::Combo("##SampleColor", &current_index, colors, IM_ARRAYSIZE(colors))) {
-						bag_state.Value_8 = current_index + 1;
-						local_mec->set_bag_state(bag_state);
-					}
-				}
-				else if (bag_item->get_name().read_string() == "FUSE") {
-					const char* fuse_colors[] = { "Red", "Yellow", "Blue" };
-					int time_color = bag_state.Time_15 - 1;
-					int value_color = bag_state.Value_8 - 1;
-
-					ImGui::SetNextItemWidth(75.0f);
-					if (ImGui::Combo("##ValueColor", &value_color, fuse_colors, IM_ARRAYSIZE(fuse_colors))) {
-						bag_state.Value_8 = value_color + 1;
-						local_mec->set_bag_state(bag_state);
-					}
-
-					ImGui::SameLine();
-					ImGui::SetNextItemWidth(75.0f);
-					if (ImGui::Combo("##TimeColor", &time_color, fuse_colors, IM_ARRAYSIZE(fuse_colors))) {
-						bag_state.Time_15 = time_color + 1;
-						local_mec->set_bag_state(bag_state);
-					}
-				}
-				else if (bag_item->get_name().read_string() == "VENT FILTER") {
-					int clean_percentage = bag_state.Value_8;
-
-					ImGui::SetNextItemWidth(90.0f);
-					if (ImGui::SliderInt("Clean %", &clean_percentage, 0, 100)) {
-						bag_state.Value_8 = clean_percentage;
-						local_mec->set_bag_state(bag_state);
-					}
-				}
-				else if (bag_item->get_name().read_string() == "BATTERY") {
-					int charge_percentage = bag_state.Value_8;
-
-					ImGui::SetNextItemWidth(90.0f);
-					if (ImGui::SliderInt("Charge %", &charge_percentage, 0, 100)) {
-						bag_state.Value_8 = charge_percentage;
-						local_mec->set_bag_state(bag_state);
-					}
-				}
-			}
-			else {
-				ImGui::Text("Bag Item: EMPTY");
-			}
-
-			if (!hand_inventory) {
-				if (ImGui::Button("Can Inventory")) {
-					if (hand_item) {
-						hand_item->set_can_inventory(!hand_inventory);
-					}
-				}
-			}
-			else {
-				if (ImGui::Button("Can't Inventory")) {
-					if (hand_item) {
-						hand_item->set_can_inventory(!hand_inventory);
-					}
+					calculatedHeight += itemHeight;
 				}
 			}
 		}
-		ImGui::Text("[        ONI EDIT        ]");
 
-		// Revert to the default style color
-		ImGui::PopStyleColor();
+		ImGui::EndChild();
+
+		//ImGui::SetWindowSize(ImVec2(-1, calculatedHeight));
+		if (calculatedHeight <= 200.0f) {
+			ImGui::SetWindowSize(ImVec2(300.0f, 200.0f));
+		}
+		else {
+			ImGui::SetWindowSize(ImVec2(300.0f, calculatedHeight));
+		}
+
+
+		ImGui::PopStyleColor(3);
 
 		ImGui::End();
 	}

--- a/protocol.vcxproj
+++ b/protocol.vcxproj
@@ -144,6 +144,7 @@
     <ClInclude Include="config.h" />
     <ClInclude Include="game_structures.hpp" />
     <ClInclude Include="globals.h" />
+    <ClInclude Include="ItemProperties.h" />
     <ClInclude Include="mem.hpp" />
     <ClInclude Include="game_math.hpp" />
     <ClInclude Include="menu.h" />

--- a/protocol.vcxproj.filters
+++ b/protocol.vcxproj.filters
@@ -110,6 +110,9 @@
     <ClInclude Include="globals.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ItemProperties.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="overlay\imgui\imgui_impl_metal.mm">


### PR DESCRIPTION
Forked changes should be merged successfully.

New:
Fixed label on ImGui for "bag item: {bag_item} - capitalized `B`. Fixed melee range change when infinite melee is disabled. Added Fish to hand and bag state changes.
Added different rices to containers for change hand/bag state. Added Puzzushi to hand/bag item on ImGui.
Added item_state offset to world_item.
Added item_state value's to ESP for items.
Added toggle for each item esp for extra details.
Changed slider color from pink to the same blue as checkboxes. Changed slider width to by dynamic to the width of the menu. Changed button width to be dynamic to the width of the menu. Changed dropdown's width to be dynamic to the width of the menu. Changed menu height to be dynamic based on content visible. Changed collapsing headers to be tab pages for esp, player, weapon and items. Added ItemProperties.h
	Defines a structure for item-specific properties (like cast time, range, cost) and provides functions to initialize and retrieve these properties efficiently for each game item.
Fixed melee item properties after fast melee / infinite melee range toggled off.